### PR TITLE
Changing auth scope

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -59,9 +59,9 @@ class SlackAuthenticator < ::Auth::OAuth2Authenticator
 
   def register_middleware(omniauth)
     unless TEAM_ID.nil?
-     omniauth.provider :slack, CLIENT_ID, CLIENT_SECRET, scope: 'identify, read', team: TEAM_ID
+     omniauth.provider :slack, CLIENT_ID, CLIENT_SECRET, scope: 'identify, users:read', team: TEAM_ID
     else
-     omniauth.provider :slack, CLIENT_ID, CLIENT_SECRET, scope: 'identify, read'
+     omniauth.provider :slack, CLIENT_ID, CLIENT_SECRET, scope: 'identify, users:read'
     end
   end
 end


### PR DESCRIPTION
"read" scope is deprecated and strongly discouraged: https://api.slack.com/docs/oauth-scopes

PS. My other concern is that Slack is asking about scope every time user login. Not sure if it is intentional.
